### PR TITLE
fix items list, all items added after first item have id 1

### DIFF
--- a/src/components/Budget_Form/BudgetForm.jsx
+++ b/src/components/Budget_Form/BudgetForm.jsx
@@ -53,7 +53,7 @@ const BudgetForm = () => {
 		switch (type) {
 			case 'inc':
 				if (incomes.length > 0) {
-					ID = Number((incomes[incomes.length - 1].id) + 1);
+					ID = Number((incomes[0].id) + 1);
 				} else {
 					ID = 0;
 				}
@@ -67,7 +67,7 @@ const BudgetForm = () => {
 
 			case 'exp':
 				if (expenses.length > 0) {
-					ID = Number((expenses[expenses.length - 1].id) + 1);
+					ID = Number((expenses[0].id) + 1);
 				} else {
 					ID = 0;
 				}


### PR DESCRIPTION
When I have 3 or more items in the list and I try to delete one, it deletes all but the first one.  I checked the console and saw that all the array elements had id = 1 (except the first one with id = 0). That's why this happens. So, with these changes I was able to fix it